### PR TITLE
Feature fix issue 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ $ python3 -m pip install Django
 $ python3 -m pip install -r requirements.txt
 ```
 
-Testing by development server. You need to comment-out the SSL session in `g14Dashboard/settings.py`:
+Testing by development server. You need to:
+
+1. comment-out the SSL session in `mylog14Dashboard/settings.py`
+
+2. Change DEBUG to False in `mylog14Dashboard/settings.py`
+
 
 ```
 $ python3 manage.py makemigrations
 $ python3 manage.py migrate
-$ python3 manage.py collectstatic
 $ python3 manage.py runserver
 $ sensible-browser http://localhost:8000
 ```
@@ -29,3 +33,11 @@ alias update_mylog14='python3 manage.py makemigrations; python3 manage.py migrat
 
 
 WARNING: DASHBOARD Code will be dropped and integrated to applications/archives
+
+# Deploy
+
+WIP
+
+```
+$ python3 manage.py collectstatic
+```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Testing by development server. You need to comment-out the SSL session in `g14Da
 ```
 $ python3 manage.py makemigrations
 $ python3 manage.py migrate
+$ python3 manage.py collectstatic
 $ python3 manage.py runserver
 $ sensible-browser http://localhost:8000
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Testing by development server. You need to:
 
 1. comment-out the SSL session in `mylog14Dashboard/settings.py`
 
-2. Change DEBUG to False in `mylog14Dashboard/settings.py`
+2. Change DEBUG to True in `mylog14Dashboard/settings.py`
 
 
 ```

--- a/mylog14Dashboard/settings.py
+++ b/mylog14Dashboard/settings.py
@@ -43,7 +43,6 @@ CORS_ORIGIN_ALLOW_ALL = True
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    #'django.forms',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',

--- a/mylog14Dashboard/settings.py
+++ b/mylog14Dashboard/settings.py
@@ -198,7 +198,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = '/var/www/html/static'
 STATIC_URL = '/static/'
 
 # SSL

--- a/mylog14Dashboard/settings.py
+++ b/mylog14Dashboard/settings.py
@@ -43,6 +43,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    #'django.forms',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -197,10 +198,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
-#STATIC_ROOT = os.path.join(BASE_DIR, 'applications/archives/static')
-STATICFILES_DIRS = [
-    ('media', os.path.join(BASE_DIR, 'applications/archives/static/media')),
-]
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
 # SSL

--- a/mylog14Dashboard/urls.py
+++ b/mylog14Dashboard/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import path, include
@@ -33,5 +34,8 @@ urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),
     path('api/v1/', include(router.urls)),
 ]
+
+urlpatterns += staticfiles_urlpatterns()
+
 if settings.ADMIN_ENABLED:
     urlpatterns.append(path('admin/', admin.site.urls))


### PR DESCRIPTION
Fixes

1. the static file serving when using `DEBUG=False` with development server

2. the static file deployment when using deploying on production site

Due to the framework restriction, it seems there's no simple way to serve static files while keeping the STATIC_ROOT configured for the production environment when using `DEBUG=True` with development server

Ref: https://docs.djangoproject.com/en/2.0/howto/static-files/#serving-static-files-in-development

From now on, one should use the `python3 manage.py collectstatic` to deploy static files on production site